### PR TITLE
Checkout supported cert-manager version

### DIFF
--- a/20-install-cert-manager.md
+++ b/20-install-cert-manager.md
@@ -20,6 +20,9 @@ limitations under the License.
 
     git clone https://github.com/jetstack/cert-manager.git
 
+    # check out the latest release tag to ensure we use a supported version of cert-manager
+    git checkout v0.2.3
+
     cd cert-manager
 
     helm install --name cert-manager \


### PR DESCRIPTION
Reported by @defcronyke on GCP Slack. Current cert-manager master will not work with the guide, we need to check out the latest release tag to ensure we got a supported version of cert-manager.