### PR TITLE
Update install command to newest version

### DIFF
--- a/20-install-cert-manager.md
+++ b/20-install-cert-manager.md
@@ -18,7 +18,7 @@ limitations under the License.
 
 [cert-manager] is "pre-stable" software,so use it at your own risk. Clone its repository and deploy the Helm chart:
 
-    helm install --name cert-manager --version v0.3.1 \
+    helm install --name cert-manager --version v0.3.2 \
         --namespace kube-system stable/cert-manager
 
 


### PR DESCRIPTION
This version fixes a breaking change for Let's Encrypt, and is recommended for all users, [per the release notes](https://github.com/jetstack/cert-manager/releases/tag/v0.3.2):

>This is a bugfix release containing a critical patch for the ACME Issuer implementation.
>
>Let's Encrypt recently made a change to their API to bring it in-line with the latest ACME draft spec, which has caused cert-manager to fail to obtain Certificates in some cases. More information can be found on the Let's Encrypt forum.
>
>It is advised that all users of v0.3.x upgrade to this release immediately, as without the changes included in this release, certificate renewal will not be successful.