### PR TITLE
Remove hosts field from Ingress tls spec

### DIFF
--- a/40-deploy-an-app.md
+++ b/40-deploy-an-app.md
@@ -54,13 +54,10 @@ spec:
     servicePort: 8080
   tls:
   - secretName: www-dogs-com-tls
-    hosts:
-    - www.dogs.com
 ```
 
 Modify a few things before deploying this manifest:
 
-- Replace `www.dogs.com` with your domain name
 - Replace `dogs-com-tls` (will be used to create the TLS Secret) with a name
   that is suitable
 - Replace `helloweb` with the Ingress name that your website is running on

--- a/yaml/sample-ingress-tls.yaml
+++ b/yaml/sample-ingress-tls.yaml
@@ -27,5 +27,3 @@ spec:
     servicePort: 8080
   tls:
   - secretName: www-dogs-com-tls
-    hosts:
-    - www.dogs.com


### PR DESCRIPTION
I happened to be reading a [GKE doc on using multiple TLS certs on an Ingress](https://cloud.google.com/kubernetes-engine/docs/how-to/ingress-multi-ssl), and under the section "The hosts field of an Ingress object" it says (my emphasis added):

> An IngressSpec has a tls field that is an array of IngressTLS objects. Each IngressTLS object has a hosts field and SecretName field. **In GKE, the hosts field is not used**. GKE reads the Common Name (CN) from the certificate in the Secret. If the Common Name matches the domain name in a client request, then the load balancer presents the matching certificate to the client.

Accordingly in the example Ingress manifest they do not bother setting the `hosts` field.