### PR TITLE
Small clarification to 50-get-a-certificate.md

### DIFF
--- a/50-get-a-certificate.md
+++ b/50-get-a-certificate.md
@@ -28,7 +28,7 @@ Ingress is expected to take quite some time.
 You can view the `Certificate` resource automatically created:
 
 ```
-kg certificate
+kubectl get certificate
 NAME                CREATED AT
 www-dogs-com-tls    1m
 ```


### PR DESCRIPTION
Clarify a command that it looks like is the owner's personal alias. Just a really tiny fix.